### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -77,7 +77,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y build-essential git libpq-dev pkg-config google-chrome-stable
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -93,7 +93,7 @@ jobs:
         run: bin/rails db:test:prepare test test:system
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: screenshots


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/upload-artifact` from v4 to v6

## Breaking changes reviewed

**actions/checkout v6**: Credentials are now persisted to a separate file using `includeIf` directives. No impact for standard GitHub-hosted runner workflows — bare git commands continue to work. Only affects Docker container actions, non-GitHub runners, or Git worktrees (none apply here).

**actions/upload-artifact v6**: Switches to Node.js 24 runtime, requires Actions Runner v2.327.1+. GitHub-hosted `ubuntu-latest` runners already meet this requirement.

## Test plan
- [ ] Verify CI passes with updated action versions
- [ ] Close Dependabot PRs #43 and #44

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)